### PR TITLE
Fixed the flashcard dropdown sorting bug

### DIFF
--- a/src/components/flashcard/FilterFlashcardDropdown.tsx
+++ b/src/components/flashcard/FilterFlashcardDropdown.tsx
@@ -119,7 +119,6 @@ export default function FilterFlashcardDropdown({
 
   const debouncedFilters = useDebounce(filters, 300);
 
-  // Get filtered options based on current selections
   const degrees = filters.university
     ? getDegreesByUniversity(filters.university)
     : [];


### PR DESCRIPTION
This PR solves #8 

This pull request refactors how academic filters are applied when querying flashcard sets, ensuring that filters are only used when explicitly provided rather than defaulting to the user's academic context. It also introduces caching for fetching user flashcard subjects to improve performance. Below are the most important changes:

### Filtering Logic Refactor

* Updated the filtering logic in `getPublishedFlashcardSets` and `loadMoreUserFlashcardSets` to only apply academic filters (`university`, `degree`, `year`, `semester`) if they are explicitly provided in the filters, instead of defaulting to the user's academic context. This makes the filtering behavior more predictable and user-driven. [[1]](diffhunk://#diff-0ed7129572bd1b67bc05b5ed5db147932da572913d5c9fb045885189d3f6c5c0L53-R66) [[2]](diffhunk://#diff-0ed7129572bd1b67bc05b5ed5db147932da572913d5c9fb045885189d3f6c5c0L441-R453)

### Caching Improvements

* Introduced a cached version of `getUserFlashcardSubjects` using `unstable_cache`, with a cache configuration for one hour and appropriate tags, to reduce redundant database queries and improve performance. [[1]](diffhunk://#diff-0ed7129572bd1b67bc05b5ed5db147932da572913d5c9fb045885189d3f6c5c0R9-R18) [[2]](diffhunk://#diff-0ed7129572bd1b67bc05b5ed5db147932da572913d5c9fb045885189d3f6c5c0R402-R408) [[3]](diffhunk://#diff-0ed7129572bd1b67bc05b5ed5db147932da572913d5c9fb045885189d3f6c5c0L370-R371)

### Code Cleanup

* Removed outdated comments and simplified the logic in `FilterFlashcardDropdown.tsx` for clarity.