### PR TITLE
fix: fixing hero section CTA alignment

### DIFF
--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -67,9 +67,9 @@ export default function HeroSection() {
   return (
     <div className="w-full">
       <div className="container mx-auto">
-        <div className="relative flex flex-col items-center justify-center gap-8 py-20 lg:py-40">
+        <div className="relative flex flex-col items-center justify-center gap-8 py-0 lg:py-10">
           <Science className="absolute top-4 left-4 size-24 md:size-64" />
-          <Cap className="absolute right-10 bottom-0 size-24 md:bottom-10 md:size-64" />
+          <Cap className="absolute right-10 -bottom-16 size-24 md:bottom-10 md:size-64 lg:bottom-0" />
           <div>
             <Button variant="secondary" size="sm" className="gap-4">
               Now it is time to study{" "}


### PR DESCRIPTION
This PR aims to resolve the alignment issue where the Call-to-Action (CTA) buttons ("Visit Notes" and "Purchase Premium") were not immediately visible to users without scrolling. The changes ensure the CTA section is properly aligned and accessible at first glance.

Before-
<img width="2842" height="1632" alt="image" src="https://github.com/user-attachments/assets/e769d28d-58ef-4ea9-8070-664ed58354fe" />
After-
<img width="2836" height="1530" alt="image" src="https://github.com/user-attachments/assets/ec406605-28a5-4690-b59e-e6dc15b8febe" />
